### PR TITLE
refactor: apply react_cache to getting notion page

### DIFF
--- a/src/app/[pageId]/page.tsx
+++ b/src/app/[pageId]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import dynamic from "next/dynamic";
 import { getPageTitle } from "notion-utils";
 
-import notion from "@/app/lib/notions";
+import { getPage } from "@/app/lib/notions";
 
 import { commonTitle } from "@/app/data/metaTitle";
 
@@ -17,7 +17,7 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   try {
     const { pageId } = await params;
-    const recordMap = await notion.getPage(pageId);
+    const recordMap = await getPage(pageId);
     const title = getPageTitle(recordMap);
 
     return {
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 const Page = async ({ params }: Props) => {
   const { pageId } = await params;
-  const recordMap = await notion.getPage(pageId);
+  const recordMap = await getPage(pageId);
 
   return (
     <Suspense fallback={"loading..."}>

--- a/src/app/lib/notions.ts
+++ b/src/app/lib/notions.ts
@@ -1,4 +1,13 @@
+import { cache } from "react";
 import { NotionAPI } from "notion-client";
 
 const notion = new NotionAPI();
+
+//react cache 적용하여 한번만 호출되게 수정
+//https://nextjs-ko.org/docs/app/building-your-application/caching#react-cache-function
+export const getPage = cache(async (id: string) => {
+  const page = await notion.getPage(id);
+  return page;
+});
+
 export default notion;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,12 +4,12 @@ import { getPageTitle } from "notion-utils";
 import { commonTitle } from "./data/metaTitle";
 
 import { rootNotionPageId } from "./lib/config";
-import notion from "./lib/notions";
+import { getPage } from "./lib/notions";
 
 import NotionPage from "./components/NotionPage";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const recordMap = await notion.getPage(rootNotionPageId);
+  const recordMap = await getPage(rootNotionPageId);
   const title = getPageTitle(recordMap);
 
   return {
@@ -22,7 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Home() {
-  const recordMap = await notion.getPage(rootNotionPageId); //getting notion data on Server Side
+  const recordMap = await getPage(rootNotionPageId); //getting notion data on Server Side
 
   return (
     <main>


### PR DESCRIPTION
## 작업 종류

- [ ] Feature (새로운 기능 추가)
- [ ] Bugfix (버그 수정)
- [ ] Release
- [x] Refactor (코드 리팩토링)
- [ ] Style (코드 포맷팅, 콘솔로그 삭제 등 코드 변경이 없는 경우)
- [ ] Other, please describe:

## 작업 요약
- notion page 가져올때 리엑트 cache 적용
## 작업 내용 (가급적이면 스크린샷 첨부)
- notion.getPage(id) 함수 호출 시 캐시 적용하여 여러번 호출해도 같은 내용이면 한번만 호출되게 적용

- generateMetadata, root, [id[/page.tsx에 중복 호출 되던 부분에 적용
## 테스팅 요구사항 (어디서 무엇을 어떻게 테스트하면 되는지)
